### PR TITLE
feat: improve portfolio SEO, OG image, and about page

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,4 +1,9 @@
 {
   "MD033": false,
-  "MD013": false
+  "MD013": false,
+  "MD013": {
+    "line_length": 80,
+    "code_blocks": false,
+    "tables": false
+  }
 }

--- a/.prettierignore
+++ b/.prettierignore
@@ -10,4 +10,5 @@
 !package.json
 !.prettierrc
 !.eslintrc.js
+!.markdownlint.json
 !README.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.3.0",
       "dependencies": {
         "@astrojs/rss": "^2.4.1",
-        "@resvg/resvg-js": "^2.4.1",
+        "@resvg/resvg-js": "^2.6.2",
         "astro": "^2.4.5",
         "fuse.js": "^6.6.2",
         "github-slugger": "^2.0.0",
@@ -1459,34 +1459,36 @@
       }
     },
     "node_modules/@resvg/resvg-js": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js/-/resvg-js-2.4.1.tgz",
-      "integrity": "sha512-wTOf1zerZX8qYcMmLZw3czR4paI4hXqPjShNwJRh5DeHxvgffUS5KM7XwxtbIheUW6LVYT5fhT2AJiP6mU7U4A==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js/-/resvg-js-2.6.2.tgz",
+      "integrity": "sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q==",
+      "license": "MPL-2.0",
       "engines": {
         "node": ">= 10"
       },
       "optionalDependencies": {
-        "@resvg/resvg-js-android-arm-eabi": "2.4.1",
-        "@resvg/resvg-js-android-arm64": "2.4.1",
-        "@resvg/resvg-js-darwin-arm64": "2.4.1",
-        "@resvg/resvg-js-darwin-x64": "2.4.1",
-        "@resvg/resvg-js-linux-arm-gnueabihf": "2.4.1",
-        "@resvg/resvg-js-linux-arm64-gnu": "2.4.1",
-        "@resvg/resvg-js-linux-arm64-musl": "2.4.1",
-        "@resvg/resvg-js-linux-x64-gnu": "2.4.1",
-        "@resvg/resvg-js-linux-x64-musl": "2.4.1",
-        "@resvg/resvg-js-win32-arm64-msvc": "2.4.1",
-        "@resvg/resvg-js-win32-ia32-msvc": "2.4.1",
-        "@resvg/resvg-js-win32-x64-msvc": "2.4.1"
+        "@resvg/resvg-js-android-arm-eabi": "2.6.2",
+        "@resvg/resvg-js-android-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-x64": "2.6.2",
+        "@resvg/resvg-js-linux-arm-gnueabihf": "2.6.2",
+        "@resvg/resvg-js-linux-arm64-gnu": "2.6.2",
+        "@resvg/resvg-js-linux-arm64-musl": "2.6.2",
+        "@resvg/resvg-js-linux-x64-gnu": "2.6.2",
+        "@resvg/resvg-js-linux-x64-musl": "2.6.2",
+        "@resvg/resvg-js-win32-arm64-msvc": "2.6.2",
+        "@resvg/resvg-js-win32-ia32-msvc": "2.6.2",
+        "@resvg/resvg-js-win32-x64-msvc": "2.6.2"
       }
     },
     "node_modules/@resvg/resvg-js-android-arm-eabi": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm-eabi/-/resvg-js-android-arm-eabi-2.4.1.tgz",
-      "integrity": "sha512-AA6f7hS0FAPpvQMhBCf6f1oD1LdlqNXKCxAAPpKh6tR11kqV0YIB9zOlIYgITM14mq2YooLFl6XIbbvmY+jwUw==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm-eabi/-/resvg-js-android-arm-eabi-2.6.2.tgz",
+      "integrity": "sha512-FrJibrAk6v29eabIPgcTUMPXiEz8ssrAk7TXxsiZzww9UTQ1Z5KAbFJs+Z0Ez+VZTYgnE5IQJqBcoSiMebtPHA==",
       "cpu": [
         "arm"
       ],
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "android"
@@ -1496,12 +1498,13 @@
       }
     },
     "node_modules/@resvg/resvg-js-android-arm64": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm64/-/resvg-js-android-arm64-2.4.1.tgz",
-      "integrity": "sha512-/QleoRdPfsEuH9jUjilYcDtKK/BkmWcK+1LXM8L2nsnf/CI8EnFyv7ZzCj4xAIvZGAy9dTYr/5NZBcTwxG2HQg==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm64/-/resvg-js-android-arm64-2.6.2.tgz",
+      "integrity": "sha512-VcOKezEhm2VqzXpcIJoITuvUS/fcjIw5NA/w3tjzWyzmvoCdd+QXIqy3FBGulWdClvp4g+IfUemigrkLThSjAQ==",
       "cpu": [
         "arm64"
       ],
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "android"
@@ -1511,12 +1514,13 @@
       }
     },
     "node_modules/@resvg/resvg-js-darwin-arm64": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-arm64/-/resvg-js-darwin-arm64-2.4.1.tgz",
-      "integrity": "sha512-U1oMNhea+kAXgiEXgzo7EbFGCD1Edq5aSlQoe6LMly6UjHzgx2W3N5kEXCwU/CgN5FiQhZr7PlSJSlcr7mdhfg==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-arm64/-/resvg-js-darwin-arm64-2.6.2.tgz",
+      "integrity": "sha512-nmok2LnAd6nLUKI16aEB9ydMC6Lidiiq2m1nEBDR1LaaP7FGs4AJ90qDraxX+CWlVuRlvNjyYJTNv8qFjtL9+A==",
       "cpu": [
         "arm64"
       ],
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "darwin"
@@ -1526,12 +1530,13 @@
       }
     },
     "node_modules/@resvg/resvg-js-darwin-x64": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-x64/-/resvg-js-darwin-x64-2.4.1.tgz",
-      "integrity": "sha512-avyVh6DpebBfHHtTQTZYSr6NG1Ur6TEilk1+H0n7V+g4F7x7WPOo8zL00ZhQCeRQ5H4f8WXNWIEKL8fwqcOkYw==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-x64/-/resvg-js-darwin-x64-2.6.2.tgz",
+      "integrity": "sha512-GInyZLjgWDfsVT6+SHxQVRwNzV0AuA1uqGsOAW+0th56J7Nh6bHHKXHBWzUrihxMetcFDmQMAX1tZ1fZDYSRsw==",
       "cpu": [
         "x64"
       ],
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "darwin"
@@ -1541,12 +1546,13 @@
       }
     },
     "node_modules/@resvg/resvg-js-linux-arm-gnueabihf": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm-gnueabihf/-/resvg-js-linux-arm-gnueabihf-2.4.1.tgz",
-      "integrity": "sha512-isY/mdKoBWH4VB5v621co+8l101jxxYjuTkwOLsbW+5RK9EbLciPlCB02M99ThAHzI2MYxIUjXNmNgOW8btXvw==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm-gnueabihf/-/resvg-js-linux-arm-gnueabihf-2.6.2.tgz",
+      "integrity": "sha512-YIV3u/R9zJbpqTTNwTZM5/ocWetDKGsro0SWp70eGEM9eV2MerWyBRZnQIgzU3YBnSBQ1RcxRZvY/UxwESfZIw==",
       "cpu": [
         "arm"
       ],
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -1556,12 +1562,16 @@
       }
     },
     "node_modules/@resvg/resvg-js-linux-arm64-gnu": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-gnu/-/resvg-js-linux-arm64-gnu-2.4.1.tgz",
-      "integrity": "sha512-uY5voSCrFI8TH95vIYBm5blpkOtltLxLRODyhKJhGfskOI7XkRw5/t1u0sWAGYD8rRSNX+CA+np86otKjubrNg==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-gnu/-/resvg-js-linux-arm64-gnu-2.6.2.tgz",
+      "integrity": "sha512-zc2BlJSim7YR4FZDQ8OUoJg5holYzdiYMeobb9pJuGDidGL9KZUv7SbiD4E8oZogtYY42UZEap7dqkkYuA91pg==",
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -1571,12 +1581,16 @@
       }
     },
     "node_modules/@resvg/resvg-js-linux-arm64-musl": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-musl/-/resvg-js-linux-arm64-musl-2.4.1.tgz",
-      "integrity": "sha512-6mT0+JBCsermKMdi/O2mMk3m7SqOjwi9TKAwSngRZ/nQoL3Z0Z5zV+572ztgbWr0GODB422uD8e9R9zzz38dRQ==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-musl/-/resvg-js-linux-arm64-musl-2.6.2.tgz",
+      "integrity": "sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==",
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -1586,12 +1600,16 @@
       }
     },
     "node_modules/@resvg/resvg-js-linux-x64-gnu": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-gnu/-/resvg-js-linux-x64-gnu-2.4.1.tgz",
-      "integrity": "sha512-60KnrscLj6VGhkYOJEmmzPlqqfcw1keDh6U+vMcNDjPhV3B5vRSkpP/D/a8sfokyeh4VEacPSYkWGezvzS2/mg==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-gnu/-/resvg-js-linux-x64-gnu-2.6.2.tgz",
+      "integrity": "sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==",
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -1601,12 +1619,16 @@
       }
     },
     "node_modules/@resvg/resvg-js-linux-x64-musl": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-musl/-/resvg-js-linux-x64-musl-2.4.1.tgz",
-      "integrity": "sha512-0AMyZSICC1D7ge115cOZQW8Pcad6PjWuZkBFF3FJuSxC6Dgok0MQnLTs2MfMdKBlAcwO9dXsf3bv9tJZj8pATA==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-musl/-/resvg-js-linux-x64-musl-2.6.2.tgz",
+      "integrity": "sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==",
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -1616,12 +1638,13 @@
       }
     },
     "node_modules/@resvg/resvg-js-win32-arm64-msvc": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-arm64-msvc/-/resvg-js-win32-arm64-msvc-2.4.1.tgz",
-      "integrity": "sha512-76XDFOFSa3d0QotmcNyChh2xHwk+JTFiEQBVxMlHpHMeq7hNrQJ1IpE1zcHSQvrckvkdfLboKRrlGB86B10Qjw==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-arm64-msvc/-/resvg-js-win32-arm64-msvc-2.6.2.tgz",
+      "integrity": "sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==",
       "cpu": [
         "arm64"
       ],
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "win32"
@@ -1631,12 +1654,13 @@
       }
     },
     "node_modules/@resvg/resvg-js-win32-ia32-msvc": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-ia32-msvc/-/resvg-js-win32-ia32-msvc-2.4.1.tgz",
-      "integrity": "sha512-odyVFGrEWZIzzJ89KdaFtiYWaIJh9hJRW/frcEcG3agJ464VXkN/2oEVF5ulD+5mpGlug9qJg7htzHcKxDN8sg==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-ia32-msvc/-/resvg-js-win32-ia32-msvc-2.6.2.tgz",
+      "integrity": "sha512-har4aPAlvjnLcil40AC77YDIk6loMawuJwFINEM7n0pZviwMkMvjb2W5ZirsNOZY4aDbo5tLx0wNMREp5Brk+w==",
       "cpu": [
         "ia32"
       ],
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "win32"
@@ -1646,12 +1670,13 @@
       }
     },
     "node_modules/@resvg/resvg-js-win32-x64-msvc": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-x64-msvc/-/resvg-js-win32-x64-msvc-2.4.1.tgz",
-      "integrity": "sha512-vY4kTLH2S3bP+puU5x7hlAxHv+ulFgcK6Zn3efKSr0M0KnZ9A3qeAjZteIpkowEFfUeMPNg2dvvoFRJA9zqxSw==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-x64-msvc/-/resvg-js-win32-x64-msvc-2.6.2.tgz",
+      "integrity": "sha512-ZXtYhtUr5SSaBrUDq7DiyjOFJqBVL/dOBN7N/qmi/pO0IgiWW/f/ue3nbvu9joWE5aAKDoIzy/CxsY0suwGosQ==",
       "cpu": [
         "x64"
       ],
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "win32"
@@ -9377,6 +9402,7 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/satori/-/satori-0.8.1.tgz",
       "integrity": "sha512-XboyousIz6IThWkKtPu3EyPAYV9ALH2pyC6bXeWKqYt7zAy11Qv40nro9Oozn+DSdaloSzGxnqy3Z7iFOHrX2Q==",
+      "license": "MPL-2.0",
       "dependencies": {
         "@shuding/opentype.js": "1.4.0-beta.0",
         "css-background-parser": "^0.1.0",
@@ -12116,94 +12142,94 @@
       }
     },
     "@resvg/resvg-js": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js/-/resvg-js-2.4.1.tgz",
-      "integrity": "sha512-wTOf1zerZX8qYcMmLZw3czR4paI4hXqPjShNwJRh5DeHxvgffUS5KM7XwxtbIheUW6LVYT5fhT2AJiP6mU7U4A==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js/-/resvg-js-2.6.2.tgz",
+      "integrity": "sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q==",
       "requires": {
-        "@resvg/resvg-js-android-arm-eabi": "2.4.1",
-        "@resvg/resvg-js-android-arm64": "2.4.1",
-        "@resvg/resvg-js-darwin-arm64": "2.4.1",
-        "@resvg/resvg-js-darwin-x64": "2.4.1",
-        "@resvg/resvg-js-linux-arm-gnueabihf": "2.4.1",
-        "@resvg/resvg-js-linux-arm64-gnu": "2.4.1",
-        "@resvg/resvg-js-linux-arm64-musl": "2.4.1",
-        "@resvg/resvg-js-linux-x64-gnu": "2.4.1",
-        "@resvg/resvg-js-linux-x64-musl": "2.4.1",
-        "@resvg/resvg-js-win32-arm64-msvc": "2.4.1",
-        "@resvg/resvg-js-win32-ia32-msvc": "2.4.1",
-        "@resvg/resvg-js-win32-x64-msvc": "2.4.1"
+        "@resvg/resvg-js-android-arm-eabi": "2.6.2",
+        "@resvg/resvg-js-android-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-x64": "2.6.2",
+        "@resvg/resvg-js-linux-arm-gnueabihf": "2.6.2",
+        "@resvg/resvg-js-linux-arm64-gnu": "2.6.2",
+        "@resvg/resvg-js-linux-arm64-musl": "2.6.2",
+        "@resvg/resvg-js-linux-x64-gnu": "2.6.2",
+        "@resvg/resvg-js-linux-x64-musl": "2.6.2",
+        "@resvg/resvg-js-win32-arm64-msvc": "2.6.2",
+        "@resvg/resvg-js-win32-ia32-msvc": "2.6.2",
+        "@resvg/resvg-js-win32-x64-msvc": "2.6.2"
       }
     },
     "@resvg/resvg-js-android-arm-eabi": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm-eabi/-/resvg-js-android-arm-eabi-2.4.1.tgz",
-      "integrity": "sha512-AA6f7hS0FAPpvQMhBCf6f1oD1LdlqNXKCxAAPpKh6tR11kqV0YIB9zOlIYgITM14mq2YooLFl6XIbbvmY+jwUw==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm-eabi/-/resvg-js-android-arm-eabi-2.6.2.tgz",
+      "integrity": "sha512-FrJibrAk6v29eabIPgcTUMPXiEz8ssrAk7TXxsiZzww9UTQ1Z5KAbFJs+Z0Ez+VZTYgnE5IQJqBcoSiMebtPHA==",
       "optional": true
     },
     "@resvg/resvg-js-android-arm64": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm64/-/resvg-js-android-arm64-2.4.1.tgz",
-      "integrity": "sha512-/QleoRdPfsEuH9jUjilYcDtKK/BkmWcK+1LXM8L2nsnf/CI8EnFyv7ZzCj4xAIvZGAy9dTYr/5NZBcTwxG2HQg==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm64/-/resvg-js-android-arm64-2.6.2.tgz",
+      "integrity": "sha512-VcOKezEhm2VqzXpcIJoITuvUS/fcjIw5NA/w3tjzWyzmvoCdd+QXIqy3FBGulWdClvp4g+IfUemigrkLThSjAQ==",
       "optional": true
     },
     "@resvg/resvg-js-darwin-arm64": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-arm64/-/resvg-js-darwin-arm64-2.4.1.tgz",
-      "integrity": "sha512-U1oMNhea+kAXgiEXgzo7EbFGCD1Edq5aSlQoe6LMly6UjHzgx2W3N5kEXCwU/CgN5FiQhZr7PlSJSlcr7mdhfg==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-arm64/-/resvg-js-darwin-arm64-2.6.2.tgz",
+      "integrity": "sha512-nmok2LnAd6nLUKI16aEB9ydMC6Lidiiq2m1nEBDR1LaaP7FGs4AJ90qDraxX+CWlVuRlvNjyYJTNv8qFjtL9+A==",
       "optional": true
     },
     "@resvg/resvg-js-darwin-x64": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-x64/-/resvg-js-darwin-x64-2.4.1.tgz",
-      "integrity": "sha512-avyVh6DpebBfHHtTQTZYSr6NG1Ur6TEilk1+H0n7V+g4F7x7WPOo8zL00ZhQCeRQ5H4f8WXNWIEKL8fwqcOkYw==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-x64/-/resvg-js-darwin-x64-2.6.2.tgz",
+      "integrity": "sha512-GInyZLjgWDfsVT6+SHxQVRwNzV0AuA1uqGsOAW+0th56J7Nh6bHHKXHBWzUrihxMetcFDmQMAX1tZ1fZDYSRsw==",
       "optional": true
     },
     "@resvg/resvg-js-linux-arm-gnueabihf": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm-gnueabihf/-/resvg-js-linux-arm-gnueabihf-2.4.1.tgz",
-      "integrity": "sha512-isY/mdKoBWH4VB5v621co+8l101jxxYjuTkwOLsbW+5RK9EbLciPlCB02M99ThAHzI2MYxIUjXNmNgOW8btXvw==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm-gnueabihf/-/resvg-js-linux-arm-gnueabihf-2.6.2.tgz",
+      "integrity": "sha512-YIV3u/R9zJbpqTTNwTZM5/ocWetDKGsro0SWp70eGEM9eV2MerWyBRZnQIgzU3YBnSBQ1RcxRZvY/UxwESfZIw==",
       "optional": true
     },
     "@resvg/resvg-js-linux-arm64-gnu": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-gnu/-/resvg-js-linux-arm64-gnu-2.4.1.tgz",
-      "integrity": "sha512-uY5voSCrFI8TH95vIYBm5blpkOtltLxLRODyhKJhGfskOI7XkRw5/t1u0sWAGYD8rRSNX+CA+np86otKjubrNg==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-gnu/-/resvg-js-linux-arm64-gnu-2.6.2.tgz",
+      "integrity": "sha512-zc2BlJSim7YR4FZDQ8OUoJg5holYzdiYMeobb9pJuGDidGL9KZUv7SbiD4E8oZogtYY42UZEap7dqkkYuA91pg==",
       "optional": true
     },
     "@resvg/resvg-js-linux-arm64-musl": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-musl/-/resvg-js-linux-arm64-musl-2.4.1.tgz",
-      "integrity": "sha512-6mT0+JBCsermKMdi/O2mMk3m7SqOjwi9TKAwSngRZ/nQoL3Z0Z5zV+572ztgbWr0GODB422uD8e9R9zzz38dRQ==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-musl/-/resvg-js-linux-arm64-musl-2.6.2.tgz",
+      "integrity": "sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==",
       "optional": true
     },
     "@resvg/resvg-js-linux-x64-gnu": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-gnu/-/resvg-js-linux-x64-gnu-2.4.1.tgz",
-      "integrity": "sha512-60KnrscLj6VGhkYOJEmmzPlqqfcw1keDh6U+vMcNDjPhV3B5vRSkpP/D/a8sfokyeh4VEacPSYkWGezvzS2/mg==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-gnu/-/resvg-js-linux-x64-gnu-2.6.2.tgz",
+      "integrity": "sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==",
       "optional": true
     },
     "@resvg/resvg-js-linux-x64-musl": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-musl/-/resvg-js-linux-x64-musl-2.4.1.tgz",
-      "integrity": "sha512-0AMyZSICC1D7ge115cOZQW8Pcad6PjWuZkBFF3FJuSxC6Dgok0MQnLTs2MfMdKBlAcwO9dXsf3bv9tJZj8pATA==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-musl/-/resvg-js-linux-x64-musl-2.6.2.tgz",
+      "integrity": "sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==",
       "optional": true
     },
     "@resvg/resvg-js-win32-arm64-msvc": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-arm64-msvc/-/resvg-js-win32-arm64-msvc-2.4.1.tgz",
-      "integrity": "sha512-76XDFOFSa3d0QotmcNyChh2xHwk+JTFiEQBVxMlHpHMeq7hNrQJ1IpE1zcHSQvrckvkdfLboKRrlGB86B10Qjw==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-arm64-msvc/-/resvg-js-win32-arm64-msvc-2.6.2.tgz",
+      "integrity": "sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==",
       "optional": true
     },
     "@resvg/resvg-js-win32-ia32-msvc": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-ia32-msvc/-/resvg-js-win32-ia32-msvc-2.4.1.tgz",
-      "integrity": "sha512-odyVFGrEWZIzzJ89KdaFtiYWaIJh9hJRW/frcEcG3agJ464VXkN/2oEVF5ulD+5mpGlug9qJg7htzHcKxDN8sg==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-ia32-msvc/-/resvg-js-win32-ia32-msvc-2.6.2.tgz",
+      "integrity": "sha512-har4aPAlvjnLcil40AC77YDIk6loMawuJwFINEM7n0pZviwMkMvjb2W5ZirsNOZY4aDbo5tLx0wNMREp5Brk+w==",
       "optional": true
     },
     "@resvg/resvg-js-win32-x64-msvc": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-x64-msvc/-/resvg-js-win32-x64-msvc-2.4.1.tgz",
-      "integrity": "sha512-vY4kTLH2S3bP+puU5x7hlAxHv+ulFgcK6Zn3efKSr0M0KnZ9A3qeAjZteIpkowEFfUeMPNg2dvvoFRJA9zqxSw==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-x64-msvc/-/resvg-js-win32-x64-msvc-2.6.2.tgz",
+      "integrity": "sha512-ZXtYhtUr5SSaBrUDq7DiyjOFJqBVL/dOBN7N/qmi/pO0IgiWW/f/ue3nbvu9joWE5aAKDoIzy/CxsY0suwGosQ==",
       "optional": true
     },
     "@shuding/opentype.js": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@astrojs/rss": "^2.4.1",
-    "@resvg/resvg-js": "^2.4.1",
+    "@resvg/resvg-js": "^2.6.2",
     "astro": "^2.4.5",
     "fuse.js": "^6.6.2",
     "github-slugger": "^2.0.0",

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -4,7 +4,7 @@ import Hr from "./Hr.astro";
 import LinkButton from "./LinkButton.astro";
 
 export interface Props {
-  activeNav?: "posts" | "tags" | "about" | "search" | "projects";
+  activeNav?: "posts" | "about" | "search" | "projects";
 }
 
 const { activeNav } = Astro.props;
@@ -58,11 +58,6 @@ const { activeNav } = Astro.props;
           <li>
             <a href="/posts" class={activeNav === "posts" ? "active" : ""}>
               Posts
-            </a>
-          </li>
-          <li>
-            <a href="/tags" class={activeNav === "tags" ? "active" : ""}>
-              Tags
             </a>
           </li>
           <li>
@@ -147,7 +142,7 @@ const { activeNav } = Astro.props;
     @apply flex w-full flex-col items-center bg-skin-fill sm:ml-2 sm:flex-row sm:justify-end sm:space-x-4 sm:py-0;
   }
   nav ul {
-    @apply mt-4 grid w-44 grid-cols-2 grid-rows-4 gap-x-2 gap-y-2 sm:ml-0 sm:mt-0 sm:w-auto sm:gap-x-5 sm:gap-y-0;
+    @apply mt-4 grid w-44 grid-cols-2 grid-rows-3 gap-x-2 gap-y-2 sm:ml-0 sm:mt-0 sm:w-auto sm:gap-x-5 sm:gap-y-0;
   }
   nav ul li {
     @apply col-span-2 flex items-center justify-center;
@@ -155,11 +150,11 @@ const { activeNav } = Astro.props;
   nav ul li a {
     @apply w-full px-4 py-3 text-center font-medium hover:text-skin-accent sm:my-0 sm:px-2 sm:py-1;
   }
-  nav ul li:nth-child(5) a {
+  nav ul li:nth-child(4) a {
     @apply w-auto;
   }
-  nav ul li:nth-child(5),
-  nav ul li:nth-child(6) {
+  nav ul li:nth-child(4),
+  nav ul li:nth-child(5) {
     @apply col-span-1;
   }
   nav a.active {

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,9 +3,9 @@ import type { Site, SocialObjects } from "./types";
 export const SITE: Site = {
   website: "http://www.allan-gallo.com",
   author: "Allan Gallo",
-  desc: "Blog and Portfolio",
+  desc: "Allan Gallo — Software Engineer with 11+ years of experience in TypeScript, React, AWS, and data engineering. Writing about web dev, cloud architecture, and software craft.",
   title: "Allan Gallo",
-  ogImage: "astropaper-og.jpg",
+  ogImage: "og.png",
   lightAndDarkMode: true,
   postPerPage: 3,
 };
@@ -27,18 +27,6 @@ export const SOCIALS: SocialObjects = [
     active: true,
   },
   {
-    name: "Facebook",
-    href: "https://github.com/satnaing/astro-paper",
-    linkTitle: `${SITE.title} on Facebook`,
-    active: false,
-  },
-  {
-    name: "Instagram",
-    href: "https://github.com/satnaing/astro-paper",
-    linkTitle: `${SITE.title} on Instagram`,
-    active: false,
-  },
-  {
     name: "LinkedIn",
     href: "https://www.linkedin.com/in/aogallo/",
     linkTitle: `${SITE.title} on LinkedIn`,
@@ -48,7 +36,7 @@ export const SOCIALS: SocialObjects = [
     name: "Mail",
     href: "mailto:allan.gallo.guerra@gmail.com",
     linkTitle: `Send an email to ${SITE.title}`,
-    active: false,
+    active: true,
   },
   {
     name: "Twitter",

--- a/src/constants/skills.ts
+++ b/src/constants/skills.ts
@@ -1,6 +1,6 @@
 export const skills = [
   {
-    name: "Javacript",
+    name: "JavaScript",
     href: "https://developer.mozilla.org/en-US/docs/Web/JavaScript",
   },
   { name: "Typescript", href: "https://www.typescriptlang.org" },

--- a/src/pages/about.md
+++ b/src/pages/about.md
@@ -2,15 +2,28 @@
 layout: ../layouts/AboutLayout.astro
 title: About
 ---
-I'm a Software Engineer with a robust technical stack spanning multiple programming languages and cloud technologies.
 
-My expertise spans Typescript, Node.js, React.js, React Native, Expo, Astro, and SSR with Next.js for web and mobile application development.
+[⬇ Download Resume](/resume.pdf)
 
-On the back-end, I work with AWS services, Apache Airflow, Data pipelines, languages such as Typescript, Python, and Golang with experience in REST and GraphQl APIs.
+I'm a Software Engineer with 11+ years of experience building web, mobile, and data engineering solutions across multiple industries.
 
-Database technologies in my toolkit include MongoDB, DynamoDB, PostgreSQl, and Microsoft SQL Server.
+My expertise spans TypeScript, Node.js, React.js, React Native, Expo, Astro, and SSR with Next.js for web and mobile application development.
 
-Also, I'm an Neovim enthusiast with a custom configuration, reflecting my commitment to optimizing my development workflow.
+On the back-end, I work with AWS services, Apache Airflow, Data pipelines, languages such as Typescript, Python, and Golang with experience in REST and GraphQL APIs.
+
+Database technologies in my toolkit include MongoDB, DynamoDB, PostgreSQL, and Microsoft SQL Server.
+
+Also, I'm a Neovim enthusiast with a custom configuration, reflecting my commitment to optimizing my development workflow.
+
+## Experience
+
+**[Job Title]** · [Company] · [Year] – Present
+Brief description of your role and key impact.
+
+**[Job Title]** · [Company] · [Year] – [Year]
+Brief description of your role and key impact.
+
+**[Job Title]** · [Company] · [Year] – [Year]
+Brief description of your role and key impact.
 
 ## Tech Stack
-

--- a/src/pages/og.png.ts
+++ b/src/pages/og.png.ts
@@ -1,0 +1,131 @@
+import type { APIRoute } from "astro";
+import { Resvg } from "@resvg/resvg-js";
+import satori from "satori";
+import { SITE } from "@config";
+
+export const get: APIRoute = async () => {
+  const fontData = await fetch(
+    "https://api.fontsource.org/v1/fonts/inter/latin-400-normal.woff"
+  ).then(res => res.arrayBuffer());
+
+  const fontBoldData = await fetch(
+    "https://api.fontsource.org/v1/fonts/inter/latin-700-normal.woff"
+  ).then(res => res.arrayBuffer());
+
+  const svg = await satori(
+    {
+      type: "div",
+      props: {
+        style: {
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "flex-start",
+          justifyContent: "center",
+          background: "#f4f4f5",
+          padding: "80px",
+          fontFamily: "Inter",
+        },
+        children: [
+          {
+            type: "div",
+            props: {
+              style: {
+                display: "flex",
+                flexDirection: "column",
+                gap: "16px",
+              },
+              children: [
+                {
+                  type: "div",
+                  props: {
+                    style: {
+                      fontSize: 72,
+                      fontWeight: 700,
+                      color: "#1a1a1a",
+                      lineHeight: 1.1,
+                    },
+                    children: SITE.author,
+                  },
+                },
+                {
+                  type: "div",
+                  props: {
+                    style: {
+                      fontSize: 32,
+                      fontWeight: 400,
+                      color: "#52525b",
+                      marginTop: 8,
+                    },
+                    children: "Software Engineer · 11+ years",
+                  },
+                },
+                {
+                  type: "div",
+                  props: {
+                    style: {
+                      display: "flex",
+                      alignItems: "center",
+                      gap: "12px",
+                      marginTop: 32,
+                    },
+                    children: [
+                      {
+                        type: "div",
+                        props: {
+                          style: {
+                            width: 48,
+                            height: 4,
+                            background: "#3b82f6",
+                            borderRadius: 2,
+                          },
+                          children: "",
+                        },
+                      },
+                      {
+                        type: "div",
+                        props: {
+                          style: {
+                            fontSize: 24,
+                            color: "#71717a",
+                          },
+                          children: SITE.website.replace("http://", ""),
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+    {
+      width: 1200,
+      height: 630,
+      fonts: [
+        {
+          name: "Inter",
+          data: fontData,
+          weight: 400,
+          style: "normal",
+        },
+        {
+          name: "Inter",
+          data: fontBoldData,
+          weight: 700,
+          style: "normal",
+        },
+      ],
+    }
+  );
+
+  const resvg = new Resvg(svg);
+  const png = resvg.render().asPng();
+
+  return new Response(png, {
+    headers: { "Content-Type": "image/png" },
+  });
+};

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -36,7 +36,7 @@ const tagPosts = getPostsByTag(posts, tag);
 ---
 
 <Layout title={`Tag:${tag} | ${SITE.title}`}>
-  <Header activeNav="tags" />
+  <Header />
   <Main
     pageTitle={`Tag:${tag}`}
     pageDesc={`All the articles with the tag "${tag}".`}

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -14,7 +14,7 @@ let tags = getUniqueTags(posts);
 ---
 
 <Layout title={`Tags | ${SITE.title}`}>
-  <Header activeNav="tags" />
+  <Header />
   <Main pageTitle="Tags" pageDesc="All the tags used in posts.">
     <ul>
       {tags.map(tag => <Tag name={tag} size="lg" />)}


### PR DESCRIPTION
## Summary

- **Dynamic OG image**: New `src/pages/og.png.ts` endpoint using `satori` + `@resvg/resvg-js` generates a branded 1200×630 PNG at build time — name, title, and URL with blue accent line
- **SEO meta description**: Replaced generic "Blog and Portfolio" with a keyword-rich description (160 chars) visible in Google search previews and social shares
- **About page**: Added resume download link at the top, updated copy to highlight 11+ years of experience, and added `## Experience` section with timeline placeholders
- **Nav cleanup**: Removed Tags from main nav — tags remain discoverable via post tag chips; fixed mobile CSS `nth-child` selectors and `grid-rows` accordingly
- **Fix**: Typo `Javacript` → `JavaScript` in skills constants

## Pending (user action required)

- Fill in real work experience in `src/pages/about.md` (placeholders added)
- Drop resume PDF at `/public/resume.pdf`

## Test plan

- [ ] `npm run build` completes without errors
- [ ] `dist/og.png` exists and displays correctly (1200×630, branded)
- [ ] `/about` shows resume link and Experience section
- [ ] Main nav shows Posts, About, Projects, Search — no Tags
- [ ] Tags pages still render correctly at `/tags` and `/tags/[tag]`